### PR TITLE
change process for getting session token

### DIFF
--- a/server.R
+++ b/server.R
@@ -12,10 +12,12 @@
 library(shiny)
 library(synapser)
 
+# For testing against staging
+PythonEmbedInR::pyExec("syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINTS)")
+
 shinyServer(function(input, output, session) {
   
-  session$sendCustomMessage(type="readCookie",
-                            message=list(name='org.sagebionetworks.security.user.login.token'))
+  session$sendCustomMessage(type="readCookie")
   
   foo <- observeEvent(input$cookie, {
     

--- a/server.R
+++ b/server.R
@@ -12,6 +12,9 @@
 library(shiny)
 library(synapser)
 
+# For testing against staging
+PythonEmbedInR::pyExec("syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINTS)")
+
 shinyServer(function(input, output, session) {
   
   session$sendCustomMessage(type="readCookie",

--- a/server.R
+++ b/server.R
@@ -17,7 +17,7 @@ shinyServer(function(input, output, session) {
   foo <- observe({
     
     r <- httr::GET("https://staging.synapse.org/Portal/sessioncookie")
-    
+    message(sprintf("Status code = %s", r$status_code))
     if (r$status_code == 200) {
       synapseLogin(sessionToken=r$content)
     }

--- a/server.R
+++ b/server.R
@@ -10,7 +10,7 @@
 # https://www.synapse.org
 
 library(shiny)
-library(synapseClient)
+library(synapser)
 
 shinyServer(function(input, output, session) {
   
@@ -19,10 +19,10 @@ shinyServer(function(input, output, session) {
   
   foo <- observeEvent(input$cookie, {
     
-    synapseLogin(sessionToken=input$cookie)
+    synLogin(sessionToken=input$cookie)
     
     output$title <- renderUI({
-      titlePanel(sprintf("Welcome, %s", synGetUserProfile()@userName))
+      titlePanel(sprintf("Welcome, %s", synGetUserProfile()$userName))
     })
     
     output$distPlot <- renderPlot({

--- a/server.R
+++ b/server.R
@@ -13,14 +13,13 @@ library(shiny)
 library(synapseClient)
 
 shinyServer(function(input, output, session) {
-
-  foo <- observe({
+  
+  session$sendCustomMessage(type="readCookie",
+                            message=list(name='org.sagebionetworks.security.user.login.token'))
+  
+  foo <- observeEvent(input$cookie, {
     
-    r <- httr::GET("https://staging.synapse.org/Portal/sessioncookie")
-    message(sprintf("Status code = %s", r$status_code))
-    if (r$status_code == 200) {
-      synapseLogin(sessionToken=r$content)
-    }
+    synapseLogin(sessionToken=input$cookie)
     
     output$title <- renderUI({
       titlePanel(sprintf("Welcome, %s", synGetUserProfile()@userName))

--- a/server.R
+++ b/server.R
@@ -14,12 +14,13 @@ library(synapseClient)
 
 shinyServer(function(input, output, session) {
 
-  session$sendCustomMessage(type="readCookie",
-                            message=list(name='org.sagebionetworks.security.user.login.token'))
-  
-  foo <- observeEvent(input$cookie, {
+  foo <- observe({
     
-    synapseLogin(sessionToken=input$cookie)
+    r <- httr::GET("https://staging.synapse.org/Portal/sessioncookie")
+    
+    if (r$status_code == 200) {
+      synapseLogin(sessionToken=r$content)
+    }
     
     output$title <- renderUI({
       titlePanel(sprintf("Welcome, %s", synGetUserProfile()@userName))

--- a/server.R
+++ b/server.R
@@ -17,7 +17,7 @@ PythonEmbedInR::pyExec("syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINT
 
 shinyServer(function(input, output, session) {
   
-  session$sendCustomMessage(type="readCookie")
+  session$sendCustomMessage(type="readCookie", message=list())
   
   foo <- observeEvent(input$cookie, {
     

--- a/server.R
+++ b/server.R
@@ -12,9 +12,6 @@
 library(shiny)
 library(synapser)
 
-# For testing against staging
-PythonEmbedInR::pyExec("syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINTS)")
-
 shinyServer(function(input, output, session) {
   
   session$sendCustomMessage(type="readCookie",

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -5,13 +5,9 @@ Shiny.addCustomMessageHandler("readCookie", function(message) {
 });
 
 function readCookie() {
-	name = "org.sagebionetworks.security.user.login.token";
-	var nameEQ = name + "=";
-	var ca = document.cookie.split(';');
-	for(var i=0;i < ca.length;i++) {
-		var c = ca[i];
-		while (c.charAt(0)==' ') c = c.substring(1, c.length);
-		if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
-	}
-	return null;
+  const Http = new XMLHttpRequest();
+  const url='https://staging.synapse.org/Portal/sessioncookie';
+  Http.open("GET", url);
+  Http.send();
+  Http.onreadystatechange=(e)=>{return(Http.responseText)};
 }

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -1,14 +1,17 @@
 // read the user login token from a cookie
 Shiny.addCustomMessageHandler("readCookie", function(message) {
-    var cookie = readCookie();
-    Shiny.onInputChange("cookie",cookie);
+    readCookie();
 });
 
 function readCookie() {
-  const Http = new XMLHttpRequest();
+  const xhr = new XMLHttpRequest();
   const url='https://staging.synapse.org/Portal/sessioncookie';
-  Http.withCredentials = true;
-  Http.open("GET", url);
-  Http.send();
-  Http.onreadystatechange=(e)=>{return(Http.responseText)};
+  xhr.withCredentials = true;
+  xhr.onreadystatechange = function() {
+     if (xhr.readyState == XMLHttpRequest.DONE) {
+         Shiny.onInputChange("cookie",xhr.responseText);
+     }
+  }
+  xhr.open("GET", url);
+  xhr.send();
 }

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -7,6 +7,7 @@ Shiny.addCustomMessageHandler("readCookie", function(message) {
 function readCookie() {
   const Http = new XMLHttpRequest();
   const url='https://staging.synapse.org/Portal/sessioncookie';
+  Http.withCredentials = true;
   Http.open("GET", url);
   Http.send();
   Http.onreadystatechange=(e)=>{return(Http.responseText)};


### PR DESCRIPTION
No longer allowed to directly retrieve session token from the browser cookie (https://sagebionetworks.jira.com/browse/SWC-4637). Updated JS to use a Synapse endpoint to pull. This will only work on staging for now.