### PR TITLE
Show modal message to user if not logged in

### DIFF
--- a/server.R
+++ b/server.R
@@ -15,6 +15,16 @@ library(synapser)
 shinyServer(function(input, output, session) {
   
   session$sendCustomMessage(type="readCookie", message=list())
+
+  ## Show message if user is not logged in to synapse
+  unauthorized <- observeEvent(input$authorized, {
+    showModal(
+      modalDialog(
+        title = "Not logged in",
+        HTML("You must log in to <a href=\"https://www.synapse.org/\">Synapse</a> to use this application. Please log in, and then refresh this page.")
+      )
+    )
+  })
   
   foo <- observeEvent(input$cookie, {
     

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -8,10 +8,14 @@ function readCookie() {
   const url='https://www.synapse.org/Portal/sessioncookie';
   xhr.withCredentials = true;
   xhr.onreadystatechange = function() {
-     if (xhr.readyState == XMLHttpRequest.DONE) {
-         Shiny.onInputChange("cookie",xhr.responseText);
-     }
-  }
+    if (xhr.readyState == XMLHttpRequest.DONE) {
+      if (xhr.status == 401) {
+        Shiny.onInputChange("authorized", false);
+      } else {
+        Shiny.onInputChange("cookie",xhr.responseText);
+      }
+    };
+  };
   xhr.open("GET", url);
   xhr.send();
 }


### PR DESCRIPTION
Closes #5. This pops up a message if the user is not logged in and directs them to log in on Synapse. It does not disable the UI elements that are defined in ui.R. I think it would be possible to do that with a package like shinyjs, but that seems like something people should implement for their apps themselves. 

<img width="1552" alt="Screen Shot 2019-04-03 at 2 29 58 PM" src="https://user-images.githubusercontent.com/4452678/55514468-089c1d80-561d-11e9-8c40-cd69fe858ce6.png">
