### PR TITLE
Update waiter with login prompt if not authorized

### DIFF
--- a/server.R
+++ b/server.R
@@ -20,18 +20,19 @@ shinyServer(function(input, output, session) {
 
   session$sendCustomMessage(type="readCookie", message=list())
 
-  observeEvent(input$authorized, {
-    waiter_update(
-      html = tagList(
-        img(src = "synapse_logo.png", height = "120px"),
-        h3("Looks like you're not logged in!"),
-        span("Please ", a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
-             " to Synapse, then refresh this page.")
-      )
-    )
-  })
-
   observeEvent(input$cookie, {
+
+    # If there's no session token, prompt user to log in
+    if (input$cookie == "") {
+      waiter_update(
+        html = tagList(
+          img(src = "synapse_logo.png", height = "120px"),
+          h3("Looks like you're not logged in!"),
+          span("Please ", a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
+               " to Synapse, then refresh this page.")
+        )
+      )
+    }
 
     ### login and update session; otherwise, notify to login to Synapse first
     tryCatch({
@@ -51,9 +52,12 @@ shinyServer(function(input, output, session) {
       waiter_update(
         html = tagList(
           img(src = "synapse_logo.png", height = "120px"),
-          h3("Looks like you're not logged in!"),
-          span("Please ", a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
-               " to Synapse, then refresh this page.")
+          h3("Login error"),
+          span(
+            "There was an error with the login process. Please refresh your Synapse session by logging out of and back in to",
+            a("Synapse", href = "https://www.synapse.org/", target = "_blank"),
+            ", then refresh this page."
+          )
         )
       )
     })

--- a/server.R
+++ b/server.R
@@ -23,7 +23,7 @@ shinyServer(function(input, output, session) {
   observeEvent(input$cookie, {
 
     # If there's no session token, prompt user to log in
-    if (input$cookie == "") {
+    if (input$cookie == "unauthorized") {
       waiter_update(
         html = tagList(
           img(src = "synapse_logo.png", height = "120px"),

--- a/server.R
+++ b/server.R
@@ -19,6 +19,18 @@ shinyServer(function(input, output, session) {
   syn <- synapseclient$Synapse()
 
   session$sendCustomMessage(type="readCookie", message=list())
+
+  observeEvent(input$authorized, {
+    waiter_update(
+      html = tagList(
+        img(src = "synapse_logo.png", height = "120px"),
+        h3("Looks like you're not logged in!"),
+        span("Please ", a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
+             " to Synapse, then refresh this page.")
+      )
+    )
+  })
+
   observeEvent(input$cookie, {
 
     ### login and update session; otherwise, notify to login to Synapse first

--- a/server.R
+++ b/server.R
@@ -32,35 +32,41 @@ shinyServer(function(input, output, session) {
                " to Synapse, then refresh this page.")
         )
       )
-    }
+    } else {
+      ### login and update session; otherwise, notify to login to Synapse first
+      tryCatch({
+        syn$login(sessionToken = input$cookie, rememberMe = FALSE)
 
-    ### login and update session; otherwise, notify to login to Synapse first
-    tryCatch({
-      syn$login(sessionToken = input$cookie, rememberMe = FALSE)
-
-      ### update waiter loading screen once login successful
-      waiter_update(
-        html = tagList(
-          img(src = "synapse_logo.png", height = "120px"),
-          h3(sprintf("Welcome, %s!", syn$getUserProfile()$userName))
-        )
-      )
-      Sys.sleep(2)
-      waiter_hide()
-    }, error = function(err) {
-      Sys.sleep(2)
-      waiter_update(
-        html = tagList(
-          img(src = "synapse_logo.png", height = "120px"),
-          h3("Login error"),
-          span(
-            "There was an error with the login process. Please refresh your Synapse session by logging out of and back in to",
-            a("Synapse", href = "https://www.synapse.org/", target = "_blank"),
-            ", then refresh this page."
+        ### update waiter loading screen once login successful
+        waiter_update(
+          html = tagList(
+            img(src = "synapse_logo.png", height = "120px"),
+            h3(sprintf("Welcome, %s!", syn$getUserProfile()$userName))
           )
         )
-      )
-    })
+        Sys.sleep(2)
+        waiter_hide()
+      }, error = function(err) {
+        Sys.sleep(2)
+        waiter_update(
+          html = tagList(
+            img(src = "synapse_logo.png", height = "120px"),
+            h3("Login error"),
+            span(
+              "There was an error with the login process. Please refresh your Synapse session by logging out of and back in to",
+              a("Synapse", href = "https://www.synapse.org/", target = "_blank"),
+              ", then refresh this page."
+            )
+          )
+        )
+      })
+
+      # Any shiny app functionality that uses synapse should be within the
+      # input$cookie observer
+      output$title <- renderUI({
+        titlePanel(sprintf("Welcome, %s", syn$getUserProfile()$userName))
+      })
+    }
   })
 
   output$distPlot <- renderPlot({

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -9,11 +9,7 @@ function readCookie() {
   xhr.withCredentials = true;
   xhr.onreadystatechange = function() {
     if (xhr.readyState == XMLHttpRequest.DONE) {
-      if (xhr.status == 401) {
-        Shiny.onInputChange("authorized", false);
-      } else {
-        Shiny.onInputChange("cookie",xhr.responseText);
-      }
+      Shiny.onInputChange("cookie",xhr.responseText);
     };
   };
   xhr.open("GET", url);

--- a/www/readCookie.js
+++ b/www/readCookie.js
@@ -9,7 +9,11 @@ function readCookie() {
   xhr.withCredentials = true;
   xhr.onreadystatechange = function() {
     if (xhr.readyState == XMLHttpRequest.DONE) {
-      Shiny.onInputChange("cookie",xhr.responseText);
+      if (xhr.status == 401) {
+        Shiny.onInputChange("cookie","unauthorized");
+      } else {
+        Shiny.onInputChange("cookie",xhr.responseText);
+      }
     };
   };
   xhr.open("GET", url);


### PR DESCRIPTION
I think this fixes #17 for the reticulate branch. If approved I can make the same change to the synapser version as well. With this change, the waiter screen updates and tells the user to log in if the request to get the session token returns a 401. I've deployed a copy of this app here: https://shinypro.synapse.org/users/kwoo/SynapseShinyApp-test/ (I'll update it with any future changes and take it down when this is resolved).

I've left the same `waiter_update()` in the `tryCatch()` block in case logging in _does_ throw an error. Do we want to make this a separate function since it's now repeated twice?